### PR TITLE
[ui] Local sort is now accent insensitive

### DIFF
--- a/vertigo-ui/src/main/resources/io/vertigo/ui/components/table/table.html
+++ b/vertigo-ui/src/main/resources/io/vertigo/ui/components/table/table.html
@@ -18,6 +18,7 @@
 			    th::selected.sync="|componentStates.${componentId}.selected|"
 			    th::loading="|componentStates.${componentId}.loading|"
 			    th::pagination.sync="|componentStates.${componentId}.pagination|"
+			    :sort-method="VUi.methods.sortCiAi"
 			    th:table-class="${tableClass?:'table-'+(color?:'secondary')}"
 			    th:attr="__${other_attrs}__"
 			  >

--- a/vertigo-ui/src/main/resources/io/vertigo/ui/static/js/vertigo-ui.js
+++ b/vertigo-ui/src/main/resources/io/vertigo/ui/static/js/vertigo-ui.js
@@ -304,6 +304,57 @@ var VUi = {
 					}
 					return params;
 					
+				},
+				isDate: function (v) {
+					return Object.prototype.toString.call(v) === '[object Date]';
+				},
+				isNumber: function (v) {
+					return typeof v === 'number' && isFinite(v);
+				},
+				sortDate: function (a, b) {
+					return (new Date(a)) - (new Date(b));
+				},
+				sortCiAi: function (data, sortBy, descending) {
+					const col = this.columns.find(def => def.name === sortBy);
+					if (col === null || col.field === void 0) {
+						return data;
+					}
+					
+					const
+					  dir = descending === true ? -1 : 1,
+					  val = typeof col.field === 'function'
+					    ? v => col.field(v)
+					    : v => v[col.field]
+					
+					const collator = new Intl.Collator();
+					
+					return data.sort((a, b) => {
+						let	A = val(a),
+							B = val(b)
+							
+						if (A === null || A === void 0) {
+							return -1 * dir;
+						}
+						if (B === null || B === void 0) {
+							return 1 * dir;
+						}
+						if (col.sort !== void 0) {
+							return col.sort(A, B, a, b) * dir;
+						}
+						if (VUi.methods.isNumber(A) === true && VUi.methods.isNumber(B) === true) {
+							return (A - B) * dir;
+						}
+						if (VUi.methods.isDate(A) === true && VUi.methods.isDate(B) === true) {
+							return VUi.methods.sortDate(A, B) * dir;
+						}
+						if (typeof A === 'boolean' && typeof B === 'boolean') {
+							return (A - B) * dir;
+						}
+						
+						[A, B] = [A, B].map(s => (s + '').toLocaleString());
+						
+						return collator.compare(A, B) * dir;
+					})
 				}
 		}
 	}


### PR DESCRIPTION
Based on https://github.com/quasarframework/quasar/blob/quasar-v1.4.1/ui/src/components/table/table-sort.js but using `Intl.Collator` for String sorting.
`isDate`, `isNumber` and `sortDate` are imported dependency from quasar.
