### PR TITLE
[Account] Add wildcard security key to authorize all possible values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Running 5.0.0
     * `${cspParam2}` => `${CSP_PARAM2}`
     * `${cspParam3}` => `${CSP_PARAM3}`
 * [Ui][Quasar] Add `nullLabel` parameter for `vu:select` and `vu:field-read`.
+* [Account] Add wildcard security key to authorize all possible values (`UserAuthorizations.SECURITY_KEY_ALL_VALUES`).
 
 more to come :)
 

--- a/vertigo-account/src/main/java/io/vertigo/account/authorization/UserAuthorizations.java
+++ b/vertigo-account/src/main/java/io/vertigo/account/authorization/UserAuthorizations.java
@@ -38,9 +38,11 @@ import io.vertigo.datamodel.data.definitions.DataDefinition;
 /**
  * This class list User's Authorizations.
  *
- * @author  pchretien, npiedeloup
+ * @author pchretien, npiedeloup
  */
 public final class UserAuthorizations implements Serializable {
+
+	public static final String SECURITY_KEY_ALL_VALUES = "*";
 
 	private static final long serialVersionUID = -7924146007592711123L;
 
@@ -83,6 +85,7 @@ public final class UserAuthorizations implements Serializable {
 
 	/**
 	 * Return roles set of this user.
+	 *
 	 * @return roles set
 	 */
 	public Set<Role> getRoles() {
@@ -104,6 +107,7 @@ public final class UserAuthorizations implements Serializable {
 	/**
 	 * Clear all roles on this user. (authorizations are cleared too)
 	 * Warning : no more rights after that.
+	 *
 	 * @return this UserAuthorizations
 	 */
 	public UserAuthorizations clearRoles() {
@@ -152,6 +156,7 @@ public final class UserAuthorizations implements Serializable {
 	/**
 	 * Return uncontextual authorizations set of this user.
 	 * It may be limited by entity right. It's usefull for UI rendering rights based.
+	 *
 	 * @return authorizations set
 	 */
 	public Set<String> getPriorAuthorizationNames() {
@@ -188,6 +193,7 @@ public final class UserAuthorizations implements Serializable {
 	/**
 	 * Clear all authorization on this user. (but only authorization : roles aren't cleared)
 	 * Warning : no more rights after that.
+	 *
 	 * @return this UserAuthorizations
 	 */
 	public UserAuthorizations clearAuthorizations() {
@@ -199,6 +205,7 @@ public final class UserAuthorizations implements Serializable {
 	/**
 	 * Return the security keys of this user.
 	 * Used for data dependent security rules.
+	 *
 	 * @return User's security keys.
 	 */
 	public Map<String, List<Serializable>> getSecurityKeys() {
@@ -220,7 +227,7 @@ public final class UserAuthorizations implements Serializable {
 				.isNotBlank(securityKey)
 				.isNotNull(value, "securityKey value of {0} can't be null, it's ambigious.\n"
 						+ "If it means 'no rights' you shouldn't set this securityKey for this user. \n"
-						+ "If it means 'any value' you should use an other securityKey (like 'couldAccessXx'),\n"
+						+ "If it means 'any value' you should use UserAuthorizations.SECURITY_KEY_ALL_VALUES,\n"
 						+ "or you may check if this security field shouldn't be a securityDimensions TREE.",
 						securityKey);
 		//-----
@@ -231,6 +238,7 @@ public final class UserAuthorizations implements Serializable {
 	/**
 	 * Clear Security Keys.
 	 * Use when user change it security perimeter.
+	 *
 	 * @return this UserAuthorizations
 	 */
 	public UserAuthorizations clearSecurityKeys() {

--- a/vertigo-account/src/main/java/io/vertigo/account/impl/authorization/dsl/translator/CriteriaSecurityRuleTranslator.java
+++ b/vertigo-account/src/main/java/io/vertigo/account/impl/authorization/dsl/translator/CriteriaSecurityRuleTranslator.java
@@ -20,6 +20,7 @@ package io.vertigo.account.impl.authorization.dsl.translator;
 import java.io.Serializable;
 import java.util.List;
 
+import io.vertigo.account.authorization.UserAuthorizations;
 import io.vertigo.account.authorization.definitions.SecurityDimension;
 import io.vertigo.account.authorization.definitions.SecurityDimensionType;
 import io.vertigo.account.authorization.definitions.rulemodel.RuleExpression;
@@ -146,6 +147,8 @@ public final class CriteriaSecurityRuleTranslator<E extends Entity> extends Abst
 			case EQ:
 				if (value == null) {
 					return Criterions.isNull(fieldName);
+				} else if (UserAuthorizations.SECURITY_KEY_ALL_VALUES.equals(value)) {
+					return Criterions.alwaysTrue();
 				}
 				return Criterions.isEqualTo(fieldName, value);
 			case GT:
@@ -159,6 +162,8 @@ public final class CriteriaSecurityRuleTranslator<E extends Entity> extends Abst
 			case NEQ:
 				if (value == null) {
 					return Criterions.isNotNull(fieldName);
+				} else if (UserAuthorizations.SECURITY_KEY_ALL_VALUES.equals(value)) {
+					return Criterions.alwaysFalse();
 				}
 				return Criterions.isNotEqualTo(fieldName, value);
 			default:

--- a/vertigo-account/src/main/java/io/vertigo/account/impl/authorization/dsl/translator/SearchSecurityRuleTranslator.java
+++ b/vertigo-account/src/main/java/io/vertigo/account/impl/authorization/dsl/translator/SearchSecurityRuleTranslator.java
@@ -20,6 +20,7 @@ package io.vertigo.account.impl.authorization.dsl.translator;
 import java.io.Serializable;
 import java.util.List;
 
+import io.vertigo.account.authorization.UserAuthorizations;
 import io.vertigo.account.authorization.definitions.SecurityDimension;
 import io.vertigo.account.authorization.definitions.rulemodel.RuleExpression;
 import io.vertigo.account.authorization.definitions.rulemodel.RuleExpression.ValueOperator;
@@ -131,12 +132,16 @@ public final class SearchSecurityRuleTranslator extends AbstractSecurityRuleTran
 			} else if (operator == ValueOperator.NEQ) {
 				query.append("(-"); //need a ' <blank> (-field:notvalue) to create a optional not
 			}
-			query.append(fieldName)
-					.append(':')
-					.append(toOperator(operator))
-					.append(strict ? "'" : "")
-					.append(userValue)
-					.append(strict ? "'" : "");
+			if (UserAuthorizations.SECURITY_KEY_ALL_VALUES.equals(userValue)) {
+				query.append("*:*");
+			} else {
+				query.append(fieldName)
+						.append(':')
+						.append(toOperator(operator))
+						.append(strict ? "'" : "")
+						.append(userValue)
+						.append(strict ? "'" : "");
+			}
 
 			if (operator == ValueOperator.NEQ && !mandatory) {
 				query.append(')');

--- a/vertigo-account/src/main/java/io/vertigo/account/impl/authorization/dsl/translator/SqlSecurityRuleTranslator.java
+++ b/vertigo-account/src/main/java/io/vertigo/account/impl/authorization/dsl/translator/SqlSecurityRuleTranslator.java
@@ -20,6 +20,7 @@ package io.vertigo.account.impl.authorization.dsl.translator;
 import java.io.Serializable;
 import java.util.List;
 
+import io.vertigo.account.authorization.UserAuthorizations;
 import io.vertigo.account.authorization.definitions.rulemodel.RuleExpression;
 import io.vertigo.account.authorization.definitions.rulemodel.RuleExpression.ValueOperator;
 import io.vertigo.account.authorization.definitions.rulemodel.RuleFixedValue;
@@ -77,8 +78,6 @@ public final class SqlSecurityRuleTranslator extends AbstractSecurityRuleTransla
 	}
 
 	private void appendExpression(final StringBuilder query, final RuleExpression expressionDefinition) {
-
-		query.append(expressionDefinition.getFieldName());
 		if (expressionDefinition.getValue() instanceof final RuleUserPropertyValue userPropertyValue) {
 			final List<Serializable> userValues = getUserCriteria(userPropertyValue.getUserProperty());
 			if (userValues.size() > 0) {
@@ -86,6 +85,7 @@ public final class SqlSecurityRuleTranslator extends AbstractSecurityRuleTransla
 					final Serializable userValue = userValues.get(0);
 					final ValueOperator operator = expressionDefinition.getOperator();
 					if (userValue == null) {
+						query.append(expressionDefinition.getFieldName());
 						if (operator == ValueOperator.NEQ) {
 							query.append(" is not null");
 						} else if (operator == ValueOperator.EQ) {
@@ -95,7 +95,15 @@ public final class SqlSecurityRuleTranslator extends AbstractSecurityRuleTransla
 							query.append(operator)
 									.append(userValue);
 						}
+					} else if (UserAuthorizations.SECURITY_KEY_ALL_VALUES.equals(userValue)) {
+						// SECURITY_KEY_ALL_VALUES means always true or always false, so no field name should be present
+						if (operator == ValueOperator.EQ) {
+							query.append("1=1"); // always true
+						} else {
+							query.append("0=1"); // always false
+						}
 					} else {
+						query.append(expressionDefinition.getFieldName());
 						//may translate > and >= to 'like' expressions
 						query
 								.append(expressionDefinition.getOperator())
@@ -104,6 +112,7 @@ public final class SqlSecurityRuleTranslator extends AbstractSecurityRuleTransla
 				} else {
 					final ValueOperator operator = expressionDefinition.getOperator();
 					if (operator == ValueOperator.EQ || operator == ValueOperator.NEQ) {
+						query.append(expressionDefinition.getFieldName());
 						if (operator == ValueOperator.NEQ) {
 							query.append(" NOT");
 						}
@@ -119,8 +128,9 @@ public final class SqlSecurityRuleTranslator extends AbstractSecurityRuleTransla
 						String inSep = "";
 						for (final Serializable userValue : userValues) {
 							query.append(inSep);
+							query.append(expressionDefinition.getFieldName());
 							query.append(operator).append(userValue);
-							inSep = " OR " + expressionDefinition.getFieldName();
+							inSep = " OR ";
 						}
 					}
 				}
@@ -128,6 +138,7 @@ public final class SqlSecurityRuleTranslator extends AbstractSecurityRuleTransla
 		} else if (expressionDefinition.getValue() instanceof RuleFixedValue) {
 			final var fixedValue = ((RuleFixedValue) expressionDefinition.getValue()).getFixedValue();
 			final var operator = expressionDefinition.getOperator();
+			query.append(expressionDefinition.getFieldName());
 			if (fixedValue == null) {
 				if (operator == ValueOperator.NEQ) {
 					query.append(" is not null");

--- a/vertigo-account/src/test/java/io/vertigo/account/authorization/AuthorizationCriteriaTest.java
+++ b/vertigo-account/src/test/java/io/vertigo/account/authorization/AuthorizationCriteriaTest.java
@@ -1,0 +1,187 @@
+/*
+ * vertigo - application development platform
+ *
+ * Copyright (C) 2013-2025, Vertigo.io, team@vertigo.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertigo.account.authorization;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertigo.account.authorization.SecurityNames.RecordAuthorizations;
+import io.vertigo.account.authorization.SecurityNames.RecordOperations;
+import io.vertigo.account.authorization.definitions.Authorization;
+import io.vertigo.account.authorization.definitions.AuthorizationName;
+import io.vertigo.account.authorization.definitions.OperationName;
+import io.vertigo.account.data.model.Record;
+import io.vertigo.account.security.UserSession;
+import io.vertigo.account.security.VSecurityManager;
+import io.vertigo.core.node.AutoCloseableNode;
+import io.vertigo.core.node.component.di.DIInjector;
+import io.vertigo.core.node.config.NodeConfig;
+import io.vertigo.core.node.definition.DefinitionSpace;
+
+/**
+ * @author skerdudou
+ */
+public final class AuthorizationCriteriaTest {
+
+	private static final String SELECT_NO_ACCESS = "select * from record where 0=1";
+	private static final String ELASTIC_NO_ACCESS = "";
+
+	//	private static final long DEFAULT_REG_ID = 1L;
+	//	private static final long DEFAULT_DEP_ID = 2L;
+	//	private static final long DEFAULT_COM_ID = 3L;
+	private static final long DEFAULT_UTI_ID = 1000L;
+	private static final long DEFAULT_TYPE_ID = 10L;
+	private static final double DEFAULT_MONTANT_MAX = 100d;
+
+	@Inject
+	private VSecurityManager securityManager;
+
+	@Inject
+	private AuthorizationManager authorizationManager;
+
+	private AutoCloseableNode node;
+
+	@BeforeEach
+	public void setUp() {
+		node = new AutoCloseableNode(buildNodeConfig());
+		DIInjector.injectMembers(this, node.getComponentSpace());
+	}
+
+	@AfterEach
+	public void tearDown() {
+		if (node != null) {
+			node.close();
+		}
+	}
+
+	private NodeConfig buildNodeConfig() {
+		return MyNodeConfig.config();
+	}
+
+	@Test
+	public void testAsSqlFrom() {
+		// Test with no authorizations
+		assertSqlCriteria(RecordOperations.read, SELECT_NO_ACCESS);
+		assertSqlCriteria(RecordOperations.write, SELECT_NO_ACCESS);
+		assertSqlCriteria(RecordOperations.create, SELECT_NO_ACCESS);
+		assertSqlCriteria(RecordOperations.delete, SELECT_NO_ACCESS);
+
+		// Test with some authorizations
+		final Authorization recRead = getAuthorization(RecordAuthorizations.AtzRecord$read);
+		final Authorization recReadHp = getAuthorization(RecordAuthorizations.AtzRecord$readHp);
+		final Authorization recWrite = getAuthorization(RecordAuthorizations.AtzRecord$write);
+		final Authorization recCreate = getAuthorization(RecordAuthorizations.AtzRecord$create);
+
+		withUserAuthorizations(DEFAULT_UTI_ID, new Authorization[] { recRead, recWrite, recCreate }, () -> {
+			assertSqlCriteria(RecordOperations.read, "select * from record where (AMOUNT <= 100.0 OR UTI_ID_OWNER = 1000)");
+			assertSqlCriteria(RecordOperations.write,
+					"select * from record where ((UTI_ID_OWNER = 1000 AND ETA_CD in ('CRE', 'VAL', 'PUB', 'NOT', 'REA')) OR (TYP_ID = 10 AND AMOUNT > 0.0 AND AMOUNT <= 100.0 AND ETA_CD in ('CRE', 'VAL', 'PUB', 'NOT', 'REA')))");
+			assertSqlCriteria(RecordOperations.create, "select * from record where (TYP_ID = 10 AND AMOUNT <= 100.0)");
+			assertSqlCriteria(RecordOperations.delete, SELECT_NO_ACCESS);
+		});
+		withUserAuthorizations(DEFAULT_UTI_ID, new Authorization[] { recReadHp, recWrite, recCreate }, () -> {
+			assertSqlCriteria(RecordOperations.read, "select * from record where 1=1");
+			assertSqlCriteria(RecordOperations.write,
+					"select * from record where ((UTI_ID_OWNER = 1000 AND ETA_CD in ('CRE', 'VAL', 'PUB', 'NOT', 'REA')) OR (TYP_ID = 10 AND AMOUNT > 0.0 AND AMOUNT <= 100.0 AND ETA_CD in ('CRE', 'VAL', 'PUB', 'NOT', 'REA')))");
+			assertSqlCriteria(RecordOperations.create, "select * from record where (TYP_ID = 10 AND AMOUNT <= 100.0)");
+			assertSqlCriteria(RecordOperations.delete, SELECT_NO_ACCESS);
+		});
+	}
+
+	@Test
+	public void testAsElasticQuery() {
+		// Test with no authorizations
+		assertSearchCriteria(RecordOperations.read, ELASTIC_NO_ACCESS);
+		assertSearchCriteria(RecordOperations.write, ELASTIC_NO_ACCESS);
+		assertSearchCriteria(RecordOperations.create, ELASTIC_NO_ACCESS);
+		assertSearchCriteria(RecordOperations.delete, ELASTIC_NO_ACCESS);
+
+		// Test with some authorizations
+		final Authorization recRead = getAuthorization(RecordAuthorizations.AtzRecord$read);
+		final Authorization recReadHp = getAuthorization(RecordAuthorizations.AtzRecord$readHp);
+		final Authorization recWrite = getAuthorization(RecordAuthorizations.AtzRecord$write);
+		final Authorization recCreate = getAuthorization(RecordAuthorizations.AtzRecord$create);
+
+		withUserAuthorizations(DEFAULT_UTI_ID, new Authorization[] { recRead, recWrite, recCreate }, () -> {
+			assertSearchCriteria(RecordOperations.read, "(+amount:<=100.0) (+utiIdOwner:1000)");
+			assertSearchCriteria(RecordOperations.write,
+					"(+utiIdOwner:1000 +etaCd:('CRE' 'VAL' 'PUB' 'NOT' 'REA')) (+typId:10 +amount:>0 +amount:<=100.0 +etaCd:('CRE' 'VAL' 'PUB' 'NOT' 'REA'))");
+			assertSearchCriteria(RecordOperations.create, "(+typId:10 +amount:<=100.0)");
+			assertSearchCriteria(RecordOperations.delete, ELASTIC_NO_ACCESS);
+		});
+		withUserAuthorizations(DEFAULT_UTI_ID, new Authorization[] { recReadHp, recWrite, recCreate }, () -> {
+			assertSearchCriteria(RecordOperations.read, "(*:*)");
+			assertSearchCriteria(RecordOperations.write,
+					"(+utiIdOwner:1000 +etaCd:('CRE' 'VAL' 'PUB' 'NOT' 'REA')) (+typId:10 +amount:>0 +amount:<=100.0 +etaCd:('CRE' 'VAL' 'PUB' 'NOT' 'REA'))");
+			assertSearchCriteria(RecordOperations.create, "(+typId:10 +amount:<=100.0)");
+			assertSearchCriteria(RecordOperations.delete, ELASTIC_NO_ACCESS);
+		});
+	}
+
+	@Test
+	public void testWildcardAuthorization() {
+		// Test with wildcard authorization
+		final Authorization recWrite = getAuthorization(RecordAuthorizations.AtzRecord$write);
+
+		withUserAuthorizations(UserAuthorizations.SECURITY_KEY_ALL_VALUES, new Authorization[] { recWrite }, () -> {
+			assertSqlCriteria(RecordOperations.write,
+					"select * from record where ((1=1 AND ETA_CD in ('CRE', 'VAL', 'PUB', 'NOT', 'REA')) OR (TYP_ID = 10 AND AMOUNT > 0.0 AND AMOUNT <= 100.0 AND ETA_CD in ('CRE', 'VAL', 'PUB', 'NOT', 'REA')))");
+			assertSearchCriteria(RecordOperations.write, "(+*:* +etaCd:('CRE' 'VAL' 'PUB' 'NOT' 'REA')) (+typId:10 +amount:>0 +amount:<=100.0 +etaCd:('CRE' 'VAL' 'PUB' 'NOT' 'REA'))");
+		});
+	}
+
+	private void withUserAuthorizations(final Serializable utiId, final Authorization[] authorizations, final Runnable testLogic) {
+		final UserSession userSession = securityManager.createUserSession();
+		try {
+			securityManager.startCurrentUserSession(userSession);
+			authorizationManager.obtainUserAuthorizations()
+					.withSecurityKeys("utiId", utiId)
+					.withSecurityKeys("typId", DEFAULT_TYPE_ID)
+					.withSecurityKeys("montantMax", DEFAULT_MONTANT_MAX);
+			for (final Authorization authorization : authorizations) {
+				authorizationManager.obtainUserAuthorizations().addAuthorization(authorization);
+			}
+			testLogic.run();
+		} finally {
+			securityManager.stopCurrentUserSession();
+		}
+	}
+
+	private void assertSqlCriteria(final OperationName<Record> operation, final String expectedSql) {
+		final var sqlCriteria = AuthorizationUtil.authorizationCriteria(Record.class, operation);
+		Assertions.assertEquals(expectedSql, sqlCriteria.asSqlFrom("record", Map.of()));
+	}
+
+	private void assertSearchCriteria(final OperationName<Record> operation, final String elasticStringQuery) {
+		final var queryString = AuthorizationUtil.getSearchSecurity(Record.class, operation);
+		Assertions.assertEquals(elasticStringQuery, queryString);
+	}
+
+	private Authorization getAuthorization(final AuthorizationName authorizationName) {
+		final DefinitionSpace definitionSpace = node.getDefinitionSpace();
+		return definitionSpace.resolve(authorizationName.name(), Authorization.class);
+	}
+
+}

--- a/vertigo-account/src/test/java/io/vertigo/account/authorization/MyNodeConfig.java
+++ b/vertigo-account/src/test/java/io/vertigo/account/authorization/MyNodeConfig.java
@@ -17,6 +17,8 @@
  */
 package io.vertigo.account.authorization;
 
+import org.h2.Driver;
+
 import io.vertigo.account.AccountFeatures;
 import io.vertigo.account.authorization.model.FullSecuredServices;
 import io.vertigo.account.authorization.model.PartialSecuredServices;
@@ -30,6 +32,8 @@ import io.vertigo.core.node.config.ModuleConfig;
 import io.vertigo.core.node.config.NodeConfig;
 import io.vertigo.core.param.Param;
 import io.vertigo.core.plugins.resource.classpath.ClassPathResourceResolverPlugin;
+import io.vertigo.database.DatabaseFeatures;
+import io.vertigo.database.impl.sql.vendor.h2.H2DataBase;
 import io.vertigo.datamodel.impl.smarttype.ModelDefinitionProvider;
 
 public final class MyNodeConfig {
@@ -39,6 +43,13 @@ public final class MyNodeConfig {
 				.withBoot(BootConfig.builder()
 						.withLocales("fr_FR")
 						.addPlugin(ClassPathResourceResolverPlugin.class)
+						.build())
+				.addModule(new DatabaseFeatures()
+						.withSqlDataBase()
+						.withC3p0(
+								Param.of("dataBaseClass", H2DataBase.class.getCanonicalName()),
+								Param.of("jdbcDriver", Driver.class.getCanonicalName()),
+								Param.of("jdbcUrl", "jdbc:h2:mem:database"))
 						.build())
 				.addModule(new AccountFeatures()
 						.withSecurity(

--- a/vertigo-account/src/test/java/io/vertigo/account/authorization/dsl/DslSecurityRulesBuilderTest.java
+++ b/vertigo-account/src/test/java/io/vertigo/account/authorization/dsl/DslSecurityRulesBuilderTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.vertigo.account.authorization.UserAuthorizations;
 import io.vertigo.account.impl.authorization.dsl.translator.CriteriaSecurityRuleTranslator;
 import io.vertigo.account.impl.authorization.dsl.translator.SearchSecurityRuleTranslator;
 import io.vertigo.account.impl.authorization.dsl.translator.SqlSecurityRuleTranslator;
@@ -65,6 +66,9 @@ public final class DslSecurityRulesBuilderTest {
 				{ "GEO<=${query} && actif=true", "'Test'", "GEO<='Test' AND actif=true", "(+GEO:<='Test' +actif:true)", "(GEO<='Test' AND actif=true)" }, //11
 				{ "ALL=null", null, "ALL is null", "(-_exists_:ALL)" }, //12
 				{ "ALL=NULL", null, "ALL is null", "(-_exists_:ALL)" }, //13
+				{ "ALL=${query}", UserAuthorizations.SECURITY_KEY_ALL_VALUES, "1=1", "(+*:*)" }, //14
+				{ "ALL=${query} && OTHER='VALID'", UserAuthorizations.SECURITY_KEY_ALL_VALUES, "1=1 AND OTHER='VALID'", "(+*:* +OTHER:'VALID')", "(1=1 AND OTHER='VALID')" }, //15
+				{ "ALL!=${query}", UserAuthorizations.SECURITY_KEY_ALL_VALUES, "0=1", "(-*:*)" }, //16
 		};
 		testSearchAndSqlQuery(testQueries);
 	}
@@ -189,9 +193,7 @@ public final class DslSecurityRulesBuilderTest {
 				case STARTS_WITH:
 					return fieldName + " startWith #" + ctx.attributeName(dtFieldName, values[0]) + "#";
 				case IN:
-					return Stream.of(values)
-							.map(Serializable::toString)
-							.collect(Collectors.joining(", ", fieldName + " in (", ")"));
+					return Stream.of(values).map(Serializable::toString).collect(Collectors.joining(", ", fieldName + " in (", ")"));
 				default:
 					throw new IllegalAccessError();
 			}

--- a/vertigo-datastore/src/main/java/io/vertigo/datastore/plugins/entitystore/sql/SqlCriteriaEncoder.java
+++ b/vertigo-datastore/src/main/java/io/vertigo/datastore/plugins/entitystore/sql/SqlCriteriaEncoder.java
@@ -143,6 +143,7 @@ public class SqlCriteriaEncoder implements CriteriaEncoder {
 						|| value instanceof Boolean
 						|| value instanceof Integer
 						|| value instanceof Long
+						|| value instanceof Double
 						|| value instanceof BigDecimal,
 				"Only String,Long,Integers and booleans are allowed in a where in clause.");
 		// we check to avoid sql injection without espacing and parametizing the statement


### PR DESCRIPTION
You should use constant `UserAuthorizations.SECURITY_KEY_ALL_VALUES` for this usage.